### PR TITLE
Take String as parameters

### DIFF
--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -31,7 +31,7 @@ async fn main() {
         warp::path("getvideo")
         .and(warp::path::end())
         .and(filter_range())
-        .and_then(move |range_header| get_range_with_cb(range_header, test_video, "video/mp4", |bytes| {
+        .and_then(move |range_header| get_range_with_cb(range_header, test_video.to_string(), "video/mp4".to_string(), |bytes| {
             callback(bytes); 
         }));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! The content is served like streaming. If you view a movie served by this filter, you can seek through it even if the file is not completely downloaded.
 //!
 //! Here is an easy example to add range to an existing warp server:
-//! ``` 
+//! ```no_run
 //! use hyper::{Body, Response};
 //! use warp::{Filter, Reply, fs::{File, dir}};
 //! use warp_range::{filter_range, get_range};
@@ -22,7 +22,7 @@
 //!         warp::path("getvideo")
 //!         .and(warp::path::end())
 //!         .and(filter_range())
-//!         .and_then(move |range_header| get_range(range_header, test_video, "video/mp4"))
+//!         .and_then(move |range_header| get_range(range_header, test_video.to_string(), "video/mp4".to_string()));
 //! 
 //!     let route_static = dir(".");
 //!     
@@ -53,16 +53,16 @@ pub fn filter_range() -> impl Filter<Extract = (Option<String>,), Error = Reject
 }
 
 /// This function retrives the range of bytes requested by the web client
-pub async fn get_range(range_header: Option<String>, file: &str, content_type: &str) -> Result<impl warp::Reply, Rejection> {
-    internal_get_range(range_header, file, content_type, None).await.map_err(|e| {
+pub async fn get_range(range_header: Option<String>, file: String, content_type: String) -> Result<impl warp::Reply, Rejection> {
+    internal_get_range(range_header, &file, &content_type, None).await.map_err(|e| {
         println!("Error in get_range: {}", e.message);
         warp::reject()
     })
 }
 
 /// This function retrives the range of bytes requested by the web client. You can define a callback function for logging purpose or media access control
-pub async fn get_range_with_cb(range_header: Option<String>, file: &str, content_type: &str, progress: fn(size: u64)) -> Result<impl warp::Reply, Rejection> {
-    internal_get_range(range_header, file, content_type, Some(progress)).await.map_err(|e| {
+pub async fn get_range_with_cb(range_header: Option<String>, file: String, content_type: String, progress: fn(size: u64)) -> Result<impl warp::Reply, Rejection> {
+    internal_get_range(range_header, &file, &content_type, Some(progress)).await.map_err(|e| {
         println!("Error in get_range: {}", e.message);
         warp::reject()
     })


### PR DESCRIPTION
I have some code where I want to dynamically generate the filename (and maybe also the MIME type) as a `String`, so my code looks something like:
```rust
    let data_endpoint = warp::path("data")
        .and(warp::path::param())
        .and(warp_range::filter_range())
        .and_then(
            |segment: String, range_header| {
                let filename: String = compute_filename(segment);
                warp_range::get_range(range_header, filename, ext_to_mime(filename))
            },
        );
```
if `get_range` takes a `&str`, then this fails to compile with a lifetime error (since the generated string `filename` only has the lifetime of the closure.

If I make it an `async move` closure, then I get errors because my `compute_filename` function relies on some data that gets moved into the closure. And, according to the compiler, "`async` non-move closures with parameters are not currently supported".

All that is to say, if I make the arguments take `String`, then I can make all of my issues go away fairly easily, at the cost of a somewhat more awkward API (you have to call `.to_string()` to convert `&str` types). This is what this PR does.

Another possibility I considered but didn't pursue would be to make `get_range` and `get_range_with_cb` no longer `async fn`s, but have them return `impl Future` with the right `Output` type. This would keep the API simpler, but I think would make the internal code more complex. I can look into that more though if you want.
